### PR TITLE
Fix file upload button disabled state for authentication in Ask.tsx

### DIFF
--- a/app/frontend/src/pages/ask/Ask.tsx
+++ b/app/frontend/src/pages/ask/Ask.tsx
@@ -285,7 +285,7 @@ export function Component(): JSX.Element {
             </Helmet>
             <div className={styles.askTopSection}>
                 <div className={styles.commandsContainer}>
-                    {showUserUpload && <UploadFile className={styles.commandButton} disabled={loggedIn} />}
+                    {showUserUpload && <UploadFile className={styles.commandButton} disabled={!loggedIn} />}
                     <SettingsButton className={styles.commandButton} onClick={() => setIsConfigPanelOpen(!isConfigPanelOpen)} />
                 </div>
                 <h1 className={styles.askTitle}>{t("askTitle")}</h1>


### PR DESCRIPTION
**Proposed Changed:** Modified loggedIn to !loggedIn of `Ask.tsx` in Line 288 such that it follows the same logic as Chat.tsx

## Purpose

Fix file upload button behavior in Ask page to properly restrict access based on authentication status. 

**Problem:** The UploadFile component in Ask.tsx was using `disabled={loggedIn}` which incorrectly disabled the button when users were logged in and enabled it when users were not logged in - the opposite of the intended behavior.

**Solution:** Changed the disabled prop to `disabled={!loggedIn}` to match the same authentication logic used in Chat.tsx, ensuring that:
- File upload functionality is disabled when no user is logged in
- File upload functionality is enabled when a user is authenticated
- Consistent behavior across both Ask and Chat pages

**Impact:** This ensures proper access control for file upload features and maintains consistent user experience throughout the application.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [X] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
